### PR TITLE
Fix mask bug, add support for scaled images.

### DIFF
--- a/canvasmask.js
+++ b/canvasmask.js
@@ -8,20 +8,26 @@
   */
   window.addEventListener('load', function(){
     [].forEach.call(document.querySelectorAll('.mask'), function(img){
-      var width  = img.offsetWidth;
-      var height = img.offsetHeight;
+      var newImg = document.createElement('img');
+      newImg.src = img.src;
+      
+      newImg.onload = function() {
+        var width  = newImg.width;
+        var height = newImg.height;
 
-      var mask = document.createElement('img');
-      mask.src = img.getAttribute('data-mask');
+        var mask = document.createElement('img');
+        mask.src = img.getAttribute('data-mask');
+        mask.onload = function() {
+          imagecanvas.width  = width;
+          imagecanvas.height = height;
 
-      imagecanvas.width  = width;
-      imagecanvas.height = height;
+          imagecontext.drawImage(mask, 0, 0, width, height);
+          imagecontext.globalCompositeOperation = 'source-atop';
+          imagecontext.drawImage(img, 0, 0);
 
-      imagecontext.drawImage(mask, 0, 0, width, height);
-      imagecontext.globalCompositeOperation = 'source-atop';
-      imagecontext.drawImage(img, 0, 0);
-
-      img.src = imagecanvas.toDataURL();
+          img.src = imagecanvas.toDataURL();
+        }
+      }
     });
   }, false);
 


### PR DESCRIPTION
Hey,

after i added your script to my website i have a few problems:
1. The new data/base64 image was completely empty. The JS generated a full transparent png.
2. When the org. image is scaled, the "new" image has not the correct dimensions.

> Wait until mask is loaded to prevent empty image bug. Add support for scaled images.
