### PR TITLE
Add support for transparent images

### DIFF
--- a/canvasmask.js
+++ b/canvasmask.js
@@ -22,7 +22,7 @@
           imagecanvas.height = height;
 
           imagecontext.drawImage(mask, 0, 0, width, height);
-          imagecontext.globalCompositeOperation = 'source-atop';
+          imagecontext.globalCompositeOperation = 'source-in';
           imagecontext.drawImage(img, 0, 0);
 
           img.src = imagecanvas.toDataURL();


### PR DESCRIPTION
Using 'source-atop' compositing fills transparent area of the image (png) with white color while 'source-in' works for both transparent and non transparent images.
